### PR TITLE
Fix Laravel Provider Namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   "extra": {
     "laravel": {
       "providers": [
-          "Glhd\\Bits\\BitsServiceProvider"
+          "Glhd\\Bits\\Support\\BitsServiceProvider"
       ]
     }
   },


### PR DESCRIPTION
The provider in composer.json pointed to the wrong namespace. This PR fixes it.
