### PR TITLE
add support for faking snowflake creation

### DIFF
--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -9,7 +9,9 @@ class Snowflake extends Bits
 {
 	public static function make(): static
 	{
-		return app(MakesSnowflakes::class)->make();
+		return static::$factory
+			? call_user_func(static::$factory)
+			: app(MakesSnowflakes::class)->make();
 	}
 	
 	public static function fromId(int|string $id): static

--- a/src/Sonyflake.php
+++ b/src/Sonyflake.php
@@ -9,7 +9,9 @@ class Sonyflake extends Bits
 {
 	public static function make(): static
 	{
-		return app(MakesSonyflakes::class)->make();
+		return static::$factory
+			? call_user_func(static::$factory)
+			: app(MakesSonyflakes::class)->make();
 	}
 	
 	public static function fromId(int|string $id): static


### PR DESCRIPTION
During testing, it may be useful to "fake" the value that is returned by the `Snowflake::make` and `Sonyflake::make` method.

This PR adds an identical API that Laravel uses for their `Str::uuid()`, `Str::ulid()`, and `Str::random()` methods for allowing fakes during testing.

I ran into a use case where I am using a snowflake in a filename, and in my tests I want to assert the filename is something deterministic, but right now, I am unable to do that.