### PR TITLE
Support Carbon v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "illuminate/support": "^9|^10|^11|12.x-dev|dev-master",
     "illuminate/contracts": "^9|^10|^11|12.x-dev|dev-master",
     "ext-json": "*",
-    "nesbot/carbon": "^2.62.1"
+    "nesbot/carbon": "^2.62.1|^3.0"
   },
   "require-dev": {
     "orchestra/testbench": "^7.10|^8|^9|9.x-dev|10.x-dev|dev-master",

--- a/tests/Unit/CustomTest.php
+++ b/tests/Unit/CustomTest.php
@@ -173,7 +173,7 @@ class CustomTest extends TestCase
 		
 		$this->assertEquals(0, $first_after_second_sleep->values[2]);
 		
-		Sleep::assertSlept(fn(CarbonInterval $interval) => $interval->totalMicroseconds === 1, 2);
+		Sleep::assertSlept(fn(CarbonInterval $interval) => (int) $interval->totalMicroseconds === 1, 2);
 	}
 	
 	public function test_custom_bits_can_be_coerced_to_snowflakes_or_sonyflakes(): void

--- a/tests/Unit/SnowflakeTest.php
+++ b/tests/Unit/SnowflakeTest.php
@@ -167,7 +167,7 @@ class SnowflakeTest extends TestCase
 		
 		Snowflake::make();
 		
-		Sleep::assertSlept(fn(CarbonInterval $interval) => $interval->totalMicroseconds === 1000);
+		Sleep::assertSlept(fn(CarbonInterval $interval) => (int) $interval->totalMicroseconds === 1000);
 	}
 	
 	public function test_a_snowflake_can_be_created_for_a_specific_timestamp(): void

--- a/tests/Unit/SonyflakeTest.php
+++ b/tests/Unit/SonyflakeTest.php
@@ -146,7 +146,7 @@ class SonyflakeTest extends TestCase
 		
 		Sonyflake::make();
 		
-		Sleep::assertSlept(fn(CarbonInterval $interval) => $interval->totalMicroseconds === 10000);
+		Sleep::assertSlept(fn(CarbonInterval $interval) => (int) $interval->totalMicroseconds === 10000);
 	}
 	
 	public function test_a_snowflake_can_be_created_for_a_specific_timestamp(): void


### PR DESCRIPTION
I was having trouble installing `bits` in a brand new Laravel 11 app, which installed Carbon v3. Currently `bits` only supports v2.

In version 3, the Carbon `->total*` properties are now floats instead of integers (see https://github.com/laravel/framework/pull/49764/commits/d1ff9a80b28fd72f8f37aa70bd5b8ab3aa26f1b0). This was causing any test using `assertSlept` to fail (e.g, `$interval->totalMicroseconds === 1` turns into `$interval->totalMicroseconds === 1.0`). 

I added a cast back into an `int` to fix the failing tests--but maybe it would be better to cast to `float`?