### PR TITLE
Add synthesizer for Livewire

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,18 +139,25 @@ make Snowflakes usable in your components.
 All you need to do is to register the synthesizer in your `AppServiceProvider`:
 
 ```php
+use Glhd\Bits\Support\Livewire\SnowflakeSynth;
+use Glhd\Bits\Support\Livewire\BitsSynth;
+
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap any application services.
-     */
     public function boot(): void
     {
+        // If only using Snowflakes:
         Livewire::propertySynthesizer(SnowflakeSynth::class);
+        
+        // If using Sonyflakes or a custom Bits variant:
+        Livewire::propertySynthesizer(BitsSynth::class);
     }
 }
 ```
 
+If you're using a non-Snowflake variant of Bits, you can use the `BitsSynth` 
+instead, which supports any version of Bits at the cost of storing a little
+more data.
 
 ## About 64-bit Unique IDs
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ $example->id instanceof Snowflake; // true
 echo $example->id; // 65898467809951744
 ```
 
+### Usage with Livewire
+
+If you're using Livewire, you can use the `SnowflakeSynth` synthesizer to
+make Snowflakes usable in your components.
+
+All you need to do is to register the synthesizer in your `AppServiceProvider`:
+
+```php
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        Livewire::propertySynthesizer(SnowflakeSynth::class);
+    }
+}
+```
+
+
 ## About 64-bit Unique IDs
 
 ### Snowflake format

--- a/src/Support/Livewire/BitsSynth.php
+++ b/src/Support/Livewire/BitsSynth.php
@@ -1,0 +1,31 @@
+<?PHP
+
+namespace Glhd\Bits\Support\Livewire;
+
+use Glhd\Bits\Bits;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+
+class BitsSynth extends Synth
+{
+	public static string $key = 'bits';
+	
+	public static function match($target)
+	{
+		return $target instanceof Bits;
+	}
+	
+	/** @var Bits $target */
+	public function dehydrate($target)
+	{
+		return [$target->jsonSerialize(), ['class' => $target::class]];
+	}
+	
+	/**
+	 * @param string $value
+	 * @param array{ class: class-string<Bits> } $meta
+	 */
+	public function hydrate($value, $meta)
+	{
+		return $meta['class']::fromId($value);
+	}
+}

--- a/src/Support/Livewire/BitsSynth.php
+++ b/src/Support/Livewire/BitsSynth.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 
 namespace Glhd\Bits\Support\Livewire;
 

--- a/src/Support/Livewire/SnowflakeSynth.php
+++ b/src/Support/Livewire/SnowflakeSynth.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 
 namespace Glhd\Bits\Support\Livewire;
 

--- a/src/Support/Livewire/SnowflakeSynth.php
+++ b/src/Support/Livewire/SnowflakeSynth.php
@@ -1,24 +1,25 @@
-<?php
+<?PHP
 
-namespace Glhd\Bits\Support;
+namespace Glhd\Bits\Support\Livewire;
 
 use Glhd\Bits\Snowflake;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 
 class SnowflakeSynth extends Synth
 {
-	public static $key = 'snowflake';
-
+	public static string $key = 'snowflake';
+	
 	public static function match($target)
 	{
 		return $target instanceof Snowflake;
 	}
-
+	
+	/** @var Snowflake $target */
 	public function dehydrate($target)
 	{
-        return [(string) $target->id(), []];
+		return [$target->jsonSerialize(), []];
 	}
-
+	
 	public function hydrate($value)
 	{
 		return Snowflake::fromId($value);

--- a/src/Support/SnowflakeSynth.php
+++ b/src/Support/SnowflakeSynth.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Glhd\Bits\Support;
+
+use Glhd\Bits\Snowflake;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+
+class SnowflakeSynth extends Synth
+{
+	public static $key = 'snowflake';
+
+	public static function match($target)
+	{
+		return $target instanceof Snowflake;
+	}
+
+	public function dehydrate($target)
+	{
+		return [$target->id(), []];
+	}
+
+	public function hydrate($value)
+	{
+		return Snowflake::fromId($value);
+	}
+}

--- a/src/Support/SnowflakeSynth.php
+++ b/src/Support/SnowflakeSynth.php
@@ -16,7 +16,7 @@ class SnowflakeSynth extends Synth
 
 	public function dehydrate($target)
 	{
-		return [$target->id(), []];
+        return [(string) $target->id(), []];
 	}
 
 	public function hydrate($value)


### PR DESCRIPTION
This PR adds a synthesizer for Livewire in order to make Snowflake usable as properties. This is also necessary to make Snowflake compatible with [Filament](https://filamentphp.com/).

See https://livewire.laravel.com/docs/synthesizers

An additional option would be, to add a service provider which would register the synthesizer automatically when Livewire is installed. If you prefer this option, I am happy to update my PR.

Thanks for your package 🎉