### PR TITLE
Add Bits-specific `setTestNow` method

### DIFF
--- a/.idea/blade.xml
+++ b/.idea/blade.xml
@@ -108,7 +108,7 @@
       <data directive="@unless" injection="true" prefix="&lt;?php&#10;if (! (" suffix=")): ?&gt;" />
       <data directive="@unset" injection="true" prefix="&lt;?php&#10;unset(" suffix="); ?&gt;" />
       <data directive="@verbatim" />
-      <data directive="@vite" injection="true" prefix="&lt;?php echo app('\\Illuminate\\Foundation\\Vite')(" suffix="); ?&gt;" />
+      <data directive="@vite" injection="true" prefix="&lt;?php echo vite_func(" suffix="); ?&gt;" />
       <data directive="@viteReactRefresh" />
       <data directive="@vitereactrefresh" />
       <data directive="@while" injection="true" prefix="&lt;?php&#10;while(" suffix="): ?&gt;" />

--- a/src/Factories/BitsFactory.php
+++ b/src/Factories/BitsFactory.php
@@ -44,7 +44,7 @@ abstract class BitsFactory implements MakesBits
 	
 	protected function now(): CarbonInterface
 	{
-		return $this->now_resolver 
+		return $this->now_resolver
 			? call_user_func($this->now_resolver)
 			: new CarbonImmutable(new DateTime());
 	}

--- a/src/Factories/BitsFactory.php
+++ b/src/Factories/BitsFactory.php
@@ -2,7 +2,10 @@
 
 namespace Glhd\Bits\Factories;
 
+use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
+use Closure;
+use DateTime;
 use Glhd\Bits\Contracts\Configuration;
 use Glhd\Bits\Contracts\MakesBits;
 use Glhd\Bits\Contracts\ResolvesSequences;
@@ -17,6 +20,8 @@ if (! class_exists(Sleep::class)) {
 
 abstract class BitsFactory implements MakesBits
 {
+	protected ?Closure $now_resolver = null;
+	
 	public function __construct(
 		public readonly CarbonInterface $epoch,
 		protected Configuration $config,
@@ -25,10 +30,29 @@ abstract class BitsFactory implements MakesBits
 		$this->validateConfiguration();
 	}
 	
+	public function setTestNow(CarbonInterface|Closure|null $now_resolver = null): static
+	{
+		if ($now_resolver instanceof CarbonInterface) {
+			$test_now = $now_resolver;
+			$now_resolver = fn() => $test_now->avoidMutation();
+		}
+		
+		$this->now_resolver = $now_resolver;
+		
+		return $this;
+	}
+	
+	protected function now(): CarbonInterface
+	{
+		return $this->now_resolver 
+			? call_user_func($this->now_resolver)
+			: new CarbonImmutable(new DateTime());
+	}
+	
 	/** @return array {0: int, 1: int} */
 	protected function waitForValidTimestampAndSequence(): array
 	{
-		$timestamp = $this->diffFromEpoch(now());
+		$timestamp = $this->diffFromEpoch($this->now());
 		$sequence = $this->sequence->next($timestamp);
 		
 		// If we've used all available numbers in sequence, we'll sleep and try again

--- a/tests/Unit/CustomTest.php
+++ b/tests/Unit/CustomTest.php
@@ -111,6 +111,7 @@ class CustomTest extends TestCase
 		$sequence = 0;
 		
 		$factory = $this->getBitsFactory(7, new TestingSequenceResolver($sequence));
+		$factory->setTestNow(now());
 		
 		$bits_at_epoch1 = $factory->make();
 		
@@ -126,7 +127,7 @@ class CustomTest extends TestCase
 		$this->assertEquals($bits_at_epoch2->values[1], 7);
 		$this->assertEquals($bits_at_epoch2->values[2], 1);
 		
-		Date::setTestNow(now()->addMicrosecond());
+		$factory->setTestNow(now()->addMicrosecond());
 		$bits_at_1us = $factory->make();
 		
 		$this->assertEquals($bits_at_1us->id(), 0b0000000000000000000000000000000000000000000000000101110000000010);
@@ -134,7 +135,7 @@ class CustomTest extends TestCase
 		$this->assertEquals($bits_at_1us->values[1], 7);
 		$this->assertEquals($bits_at_1us->values[2], 2);
 		
-		Date::setTestNow(now()->addMicrosecond());
+		$factory->setTestNow(now()->addMicroseconds(2));
 		$bits_at_2us = $factory->make();
 		
 		$this->assertEquals($bits_at_2us->id(), 0b0000000000000000000000000000000000000000000000001001110000000011);

--- a/tests/Unit/SonyflakeTest.php
+++ b/tests/Unit/SonyflakeTest.php
@@ -96,6 +96,7 @@ class SonyflakeTest extends TestCase
 		$sequence = 0;
 		
 		$factory = new SonyflakeFactory(now(), 1, app(SonyflakesConfig::class), new TestingSequenceResolver($sequence));
+		$factory->setTestNow(now());
 		
 		$sonyflake_at_epoch1 = $factory->make();
 		
@@ -111,7 +112,8 @@ class SonyflakeTest extends TestCase
 		$this->assertEquals($sonyflake_at_epoch2->machine_id, 1);
 		$this->assertEquals($sonyflake_at_epoch2->sequence, 1);
 		
-		Date::setTestNow(now()->addMilliseconds(10));
+		$factory->setTestNow(now()->addMilliseconds(10));
+		
 		$sonyflake_at_10ms = $factory->make();
 		
 		$this->assertEquals($sonyflake_at_10ms->id(), 0b0000000000000000000000000000000000000001000000100000000000000001);
@@ -119,7 +121,8 @@ class SonyflakeTest extends TestCase
 		$this->assertEquals($sonyflake_at_10ms->machine_id, 1);
 		$this->assertEquals($sonyflake_at_10ms->sequence, 2);
 		
-		Date::setTestNow(now()->addMilliseconds(10));
+		$factory->setTestNow(now()->addMilliseconds(20));
+		
 		$sonyflake_at_20ms = $factory->make();
 		
 		$this->assertEquals($sonyflake_at_20ms->id(), 0b0000000000000000000000000000000000000010000000110000000000000001);


### PR DESCRIPTION
Currently, Bits relies on Carbon, which means that if you call `Carbon::setTestNow()` that will affect the IDs that Bits generates. This is a problem in scenarios where you may time-travel back to the same date after more than 10 seconds have passed, due to the way that the Bits sequence-resolver operates.

Imagine the following scenario:

```php
// in FirstTestCase.php
Date::setTestNow('2024-07-09 00:00:00');
User::factory()->create(['id' => snowflake_id()]);

// 10 real seconds pass for some reason (maybe a large test suite)

// in SomeOtherTestCase.php
Date::setTestNow('2024-07-09 00:00:00');
User::factory()->create(['id' => snowflake_id()]); // Throws UniqueConstraintViolationException
```

This is because the Bits sequence resolver has an internal counter that resolves conflicts when two IDs are created at the exact same microsecond. So, for example, a few IDs generated all at the same microsecond might look like:

```
0 0000001100100101110101100110111100101011 01011 01111 000000000000
0 0000001100100101110101100110111100101011 01011 01111 000000000001
0 0000001100100101110101100110111100101011 01011 01111 000000000010
0 0000001100100101110101100110111100101011 01011 01111 000000000011
```

Bits only keeps track on that counter for 10 seconds, which is typically 9.9 seconds longer than necessary, but is there just to be safe. That means that if you time-travel back in time after the counter has been cleared, Bits will happily create a new ID from the beginning of the sequence.

Where this becomes a real problem is if you're using the [Verbs Wormhole](https://github.com/hirethunk/verbs/blob/main/src/Support/Wormhole.php) feature, which temporarily sets `Date::setTestNow()` in production. When that happens, many days may have passed, which means that the sequence resolver counter is long gone. That means that any event that time-travels to the same timestamp will result in the exact same ID (since timestamps are only precise down to the second, multiple events that fired at different microseconds will all result in the same timestamp and thus the same ID).

The solution is to introduce a `setTestNow()` on the Bits factory that's available for testing if you need it, but otherwise use the "real" now for ID generation regardless of what test time is set at Carbon.