### PR TITLE
Add ID resolver for AWS lambda

### DIFF
--- a/config/bits.php
+++ b/config/bits.php
@@ -42,9 +42,11 @@ return [
 	|
 	| Bits addresses this with a special lambda ID resolver, which assigns
 	| and locks IDs via your cache.
+	| 
+	| Options: true, false, or "autodetect"
 	*/
 	
-	'lambda' => (bool) env('BITS_LAMBDA', false),
+	'lambda' => env('BITS_LAMBDA', 'autodetect'),
 	
 	/*
 	|--------------------------------------------------------------------------

--- a/config/bits.php
+++ b/config/bits.php
@@ -33,6 +33,21 @@ return [
 	
 	/*
 	|--------------------------------------------------------------------------
+	| AWS Lambda (and Laravel Vapor)
+	|--------------------------------------------------------------------------
+	|
+	| Snowflakes/etc rely on unique datacenter and worker IDs to operate. 
+	| Because AWS lambdas are different machines each time, it's impossible 
+	| to assign each a unique worker/device ID.
+	|
+	| Bits addresses this with a special lambda ID resolver, which assigns
+	| and locks IDs via your cache.
+	*/
+	
+	'lambda' => (bool) env('BITS_LAMBDA', false),
+	
+	/*
+	|--------------------------------------------------------------------------
 	| Worker ID
 	|--------------------------------------------------------------------------
 	|

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,13 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	bootstrap="vendor/autoload.php"
 	colors="true"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+	cacheDirectory=".phpunit.cache"
 >
-	<coverage processUncoveredFiles="true">
-		<include>
-			<directory suffix=".php">./src</directory>
-		</include>
-	</coverage>
 	<testsuites>
 		<testsuite name="Tests">
 			<directory>./tests</directory>
@@ -26,4 +22,9 @@
 		<env name="DB_CONNECTION" value="testing"/>
 		<env name="TERMINAL_EMULATOR" value="JetBrains-JediTerm"/>
 	</php>
+	<source>
+		<include>
+			<directory>./src</directory>
+		</include>
+	</source>
 </phpunit>

--- a/src/Config/WorkerIds.php
+++ b/src/Config/WorkerIds.php
@@ -3,6 +3,7 @@
 namespace Glhd\Bits\Config;
 
 use ArrayAccess;
+use BadMethodCallException;
 use LogicException;
 
 class WorkerIds implements ArrayAccess
@@ -18,6 +19,15 @@ class WorkerIds implements ArrayAccess
 	public function first(): int
 	{
 		return $this->ids[0];
+	}
+	
+	public function second(): int
+	{
+		if (! isset($this->ids[1])) {
+			throw new BadMethodCallException('No second ID configured.');
+		}
+		
+		return $this->ids[1];
 	}
 	
 	public function offsetExists(mixed $offset): bool

--- a/src/Contracts/ResolvesIds.php
+++ b/src/Contracts/ResolvesIds.php
@@ -6,5 +6,5 @@ use Glhd\Bits\Config\WorkerIds;
 
 interface ResolvesIds
 {
-	public function get(): WorkerIds;
+	public function get(...$lengths): WorkerIds;
 }

--- a/src/Contracts/ResolvesIds.php
+++ b/src/Contracts/ResolvesIds.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Glhd\Bits\Contracts;
+
+use Glhd\Bits\Config\WorkerIds;
+
+interface ResolvesIds
+{
+	public function get(): WorkerIds;
+}

--- a/src/IdResolvers/CacheResolver.php
+++ b/src/IdResolvers/CacheResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Glhd\Bits\IdResolvers;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Support\DateFactory;
+use RuntimeException;
+
+class CacheResolver extends IdResolver
+{
+	protected ?int $value = null;
+	
+	public function __construct(
+		protected CacheManager $cache,
+		protected DateFactory $dates,
+		protected int $max = 0b1111111111,
+	) {
+	}
+	
+	protected function value(): int
+	{
+		return $this->value ??= $this->acquire();
+	}
+	
+	protected function acquire(): int
+	{
+		// First we acquire a lock to ensure no other process is reserving an ID. Then we
+		// get the current list of reserved IDs, and either find one that hasn't been
+		// reserved, or one where the reservation is expired.
+		
+		return $this->cache->lock('glhd-bits-ids:lock')
+			->block(5, function() {
+				$reserved = $this->cache->get('glhd-bits-ids:reserved', fn() => []);
+				
+				if ($id = $this->firstAvailable($reserved) ?? $this->findExpired($reserved)) {
+					$reserved[$id] = $this->dates->now()->addHour()->unix();
+					$this->cache->forever('glhd-bits-ids:reserved', $reserved);
+					return $id;
+				}
+				
+				throw new RuntimeException('Unable to acquire a unique worker ID.');
+			});
+	}
+	
+	protected function firstAvailable(array $reserved): ?int
+	{
+		for ($id = 0; $id <= $this->max; $id++) {
+			if (! isset($reserved[$id])) {
+				return $id;
+			}
+		}
+		
+		return null;
+	}
+	
+	protected function findExpired(array $reserved): ?int
+	{
+		$now = $this->dates->now()->unix();
+		
+		[$_, $id] = collect($reserved)
+			->filter(fn($expiration) => $expiration <= $now)
+			->reduce(function($carry, $expiration, $id) {
+				return $expiration < $carry[0] ? [$expiration, $id] : $carry;
+			}, [PHP_INT_MAX, null]);
+		
+		return $id;
+	}
+}

--- a/src/IdResolvers/CacheResolver.php
+++ b/src/IdResolvers/CacheResolver.php
@@ -2,6 +2,7 @@
 
 namespace Glhd\Bits\IdResolvers;
 
+use Closure;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\DateFactory;
@@ -29,8 +30,7 @@ class CacheResolver extends IdResolver
 		// get the current list of reserved IDs, and either find one that hasn't been
 		// reserved, or one where the reservation is expired.
 		
-		return $this->cache->lock('glhd-bits-ids:lock')
-			->block(5, function() {
+		return $this->lock(function() {
 				$reserved = $this->cache->get('glhd-bits-ids:reserved') ?? [];
 				$id = $this->firstAvailable($reserved) ?? $this->findExpired($reserved);
 				
@@ -42,6 +42,26 @@ class CacheResolver extends IdResolver
 				
 				throw new RuntimeException('Unable to acquire a unique worker ID.');
 			});
+	}
+	
+	protected function release(): void
+	{
+		if (null === $this->value) {
+			return;
+		}
+		
+		$this->lock(function() {
+			$reserved = $this->cache->get('glhd-bits-ids:reserved') ?? [];
+			
+			unset($reserved[$this->value]);
+			
+			$this->cache->forever('glhd-bits-ids:reserved', $reserved);
+		}, 1);
+	}
+	
+	protected function lock(Closure $callback, int $seconds = 5): mixed
+	{
+		return $this->cache->lock('glhd-bits-ids:lock')->block($seconds, $callback);
 	}
 	
 	protected function firstAvailable(array $reserved): ?int
@@ -66,5 +86,10 @@ class CacheResolver extends IdResolver
 			}, [PHP_INT_MAX, null]);
 		
 		return $id;
+	}
+	
+	public function __destruct()
+	{
+		$this->release();
 	}
 }

--- a/src/IdResolvers/IdResolver.php
+++ b/src/IdResolvers/IdResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Glhd\Bits\IdResolvers;
+
+use Glhd\Bits\Config\WorkerIds;
+use Glhd\Bits\Contracts\ResolvesIds;
+
+abstract class IdResolver implements ResolvesIds
+{
+	abstract protected function value(): int;
+	
+	public function get(...$lengths): WorkerIds
+	{
+		$value = $this->value();
+		$ids = [];
+		
+		foreach (array_reverse($lengths) as $length) {
+			$bitmask = (1 << $length) - 1;
+			array_unshift($ids, $value & $bitmask);
+			$value = $value >> $length;
+		}
+		
+		return new WorkerIds(...$ids);
+	}
+}

--- a/src/IdResolvers/StaticResolver.php
+++ b/src/IdResolvers/StaticResolver.php
@@ -14,7 +14,7 @@ class StaticResolver implements ResolvesIds
 		$this->ids = new WorkerIds(...$ids);
 	}
 	
-	public function get(): WorkerIds
+	public function get(...$lengths): WorkerIds
 	{
 		return $this->ids;
 	}

--- a/src/IdResolvers/StaticResolver.php
+++ b/src/IdResolvers/StaticResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Glhd\Bits\IdResolvers;
+
+use Glhd\Bits\Config\WorkerIds;
+use Glhd\Bits\Contracts\ResolvesIds;
+
+class StaticResolver implements ResolvesIds
+{
+	protected WorkerIds $ids;
+	
+	public function __construct(int ...$ids)
+	{
+		$this->ids = new WorkerIds(...$ids);
+	}
+	
+	public function get(): WorkerIds
+	{
+		return $this->ids;
+	}
+}

--- a/src/Support/BitsServiceProvider.php
+++ b/src/Support/BitsServiceProvider.php
@@ -40,7 +40,7 @@ class BitsServiceProvider extends ServiceProvider
 		
 		$this->app->singleton(CacheResolver::class, function(Container $container) {
 			$config = $container->make(Repository::class);
-			$cache = $container->make(CacheManager::class);
+			$cache = $container->make(CacheManager::class)->store();
 			$dates = $container->make(DateFactory::class);
 			
 			$format = $config->get('bits.format', 'snowflake');

--- a/tests/Unit/CacheIdResolverTest.php
+++ b/tests/Unit/CacheIdResolverTest.php
@@ -62,4 +62,20 @@ class CacheIdResolverTest extends TestCase
 			$resolver->get(1, 1);
 		}, RuntimeException::class);
 	}
+	
+	public function test_it_releases_sequences_on_unset(): void
+	{
+		$store = new ArrayStore();
+		
+		$resolver = new CacheResolver($store, app(DateFactory::class), 0b11);
+		$resolver->get(1, 1);
+		
+		$reserved = $store->get('glhd-bits-ids:reserved');
+		$this->assertTrue(isset($reserved[0]));
+		
+		unset($resolver);
+		
+		$reserved = $store->get('glhd-bits-ids:reserved');
+		$this->assertEquals([], $reserved);
+	}
 }

--- a/tests/Unit/CacheIdResolverTest.php
+++ b/tests/Unit/CacheIdResolverTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Glhd\Bits\Tests\Unit;
+
+use Glhd\Bits\IdResolvers\CacheResolver;
+use Glhd\Bits\Tests\TestCase;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Support\DateFactory;
+use Illuminate\Support\Facades\Date;
+use RuntimeException;
+
+class CacheIdResolverTest extends TestCase
+{
+	public function test_it_increments_sequences(): void
+	{
+		Date::setTestNow(now());
+		
+		$store = new ArrayStore();
+		
+		// Should get 0b00
+		$resolver = new CacheResolver($store, app(DateFactory::class), 0b11);
+		$this->assertEquals(0b00, $resolver->get(1, 1)->first());
+		$this->assertEquals(0b00, $resolver->get(1, 1)->second());
+		
+		Date::setTestNow(now()->addMinutes(10));
+		
+		// Should get 0b01
+		$resolver = new CacheResolver($store, app(DateFactory::class), 0b11);
+		$this->assertEquals(0b00, $resolver->get(1, 1)->first());
+		$this->assertEquals(0b01, $resolver->get(1, 1)->second());
+		
+		Date::setTestNow(now()->addMinutes(10));
+		
+		// Should get 0b10
+		$resolver = new CacheResolver($store, app(DateFactory::class), 0b11);
+		$this->assertEquals(0b01, $resolver->get(1, 1)->first());
+		$this->assertEquals(0b00, $resolver->get(1, 1)->second());
+		
+		Date::setTestNow(now()->addMinutes(10));
+		
+		// Should get 0b11
+		$resolver = new CacheResolver($store, app(DateFactory::class), 0b11);
+		$this->assertEquals(0b01, $resolver->get(1, 1)->first());
+		$this->assertEquals(0b01, $resolver->get(1, 1)->second());
+		
+		// Now we've run out of IDs… should throw
+		$this->assertThrows(function() use ($store) {
+			$resolver = new CacheResolver($store, app(DateFactory::class), 0b11);
+			$resolver->get(1, 1);
+		}, RuntimeException::class);
+		
+		Date::setTestNow(now()->addMinutes(30));
+		
+		// 0b00 has not expired, so we should be able to acquire it
+		$resolver = new CacheResolver($store, app(DateFactory::class), 0b11);
+		$this->assertEquals(0b00, $resolver->get(1, 1)->first());
+		$this->assertEquals(0b00, $resolver->get(1, 1)->second());
+		
+		// But everything else is locked, so we should throw again
+		$this->assertThrows(function() use ($store) {
+			$resolver = new CacheResolver($store, app(DateFactory::class), 0b11);
+			$resolver->get(1, 1);
+		}, RuntimeException::class);
+	}
+}


### PR DESCRIPTION
Snowflakes/etc rely on unique datacenter and worker IDs to operate. Because AWS lambdas are different machines each time, it's impossible to assign each a unique worker/device ID.

This PR adds a new ID resolution mechanism that uses cache locks to acquire a unique ID when required, and then release that ID when the process is terminated. This means that you can effectively have 1024 processes generating unique snowflake IDs in parallel.

By default, Bits will use this mechanism if the `AWS_LAMBDA_FUNCTION_NAME` environmental variable is set.