### PR TITLE
Automatic eloquent casts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     }
   },
   "scripts": {
-    "pest": "vendor/bin/pest",
+    "test": "vendor/bin/phpunit",
     "fix-style": "vendor/bin/php-cs-fixer fix",
     "check-style": "vendor/bin/php-cs-fixer fix --diff --dry-run"
   },

--- a/src/Bits.php
+++ b/src/Bits.php
@@ -49,7 +49,8 @@ class Bits implements Expression, Castable, Jsonable, JsonSerializable
 	{
 		return match (reset($arguments)) {
 			'sonyflake', 'sonyflakes' => new BitsCast(app(MakesSonyflakes::class)),
-			default => new BitsCast(app(MakesSnowflakes::class)),
+			'snowflake', 'snowflakes' => new BitsCast(app(MakesSnowflakes::class)),
+			default => new BitsCast(app(MakesBits::class)),
 		};
 	}
 	

--- a/src/Database/HasSnowflakes.php
+++ b/src/Database/HasSnowflakes.php
@@ -2,12 +2,18 @@
 
 namespace Glhd\Bits\Database;
 
-use Glhd\Bits\Snowflake;
+use Glhd\Bits\Bits;
+use Glhd\Bits\Contracts\MakesBits;
 
+/**
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
 trait HasSnowflakes
 {
 	protected function initializeHasSnowflakes(): void
 	{
+		$this->mergeCasts(array_fill_keys($this->uniqueIds(), Bits::class));
+
 		if (property_exists($this, 'usesUniqueIds')) {
 			$this->usesUniqueIds = true;
 			return;
@@ -23,7 +29,7 @@ trait HasSnowflakes
 	
 	public function newUniqueId()
 	{
-		return Snowflake::make()->id();
+		return app(MakesBits::class)->make()->id();
 	}
 	
 	public function getIncrementing()

--- a/tests/Feature/SonyflakeCastTest.php
+++ b/tests/Feature/SonyflakeCastTest.php
@@ -3,36 +3,37 @@
 namespace Glhd\Bits\Tests\Feature;
 
 use Glhd\Bits\Database\HasSnowflakes;
-use Glhd\Bits\Snowflake;
+use Glhd\Bits\Sonyflake;
 use Glhd\Bits\Tests\ResolvesSequencesFromMemory;
 use Glhd\Bits\Tests\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class SnowflakeCastTest extends TestCase
+class SonyflakeCastTest extends TestCase
 {
 	use ResolvesSequencesFromMemory;
-	
+
 	protected function setUp(): void
 	{
 		parent::setUp();
 		
-		Schema::create('test_models', function(Blueprint $table) {
+		Schema::create('test_sonyflake_models', function(Blueprint $table) {
 			$table->unsignedBigInteger('id')->primary();
 			$table->string('label')->nullable();
 			$table->timestamps();
 		});
 
-		Schema::create('test_casts_method_models', function(Blueprint $table) {
+		Schema::create('test_sonyflake_casts_method_models', function(Blueprint $table) {
 			$table->unsignedBigInteger('id')->primary();
 			$table->string('label')->nullable();
 			$table->timestamps();
 		});
 
-		Schema::create('test_automatic_casts_models', function(Blueprint $table) {
+		Schema::create('test_sonyflake_automatic_casts_models', function(Blueprint $table) {
 			$table->unsignedBigInteger('id')->primary();
 			$table->string('label')->nullable();
 			$table->timestamps();
@@ -41,19 +42,21 @@ class SnowflakeCastTest extends TestCase
 
 	/** @param class-string<Model> $class */
 	#[DataProvider('modelClassProvider')]
+	#[DefineEnvironment('usesSonyflakes')]
 	public function test_it_casts_attributes(string $class): void
 	{
 		$model1 = $class::create();
 		$model2 = $class::create();
 		
-		$this->assertInstanceOf(Snowflake::class, $model1->id);
-		$this->assertInstanceOf(Snowflake::class, $model2->id);
+		$this->assertInstanceOf(Sonyflake::class, $model1->id);
+		$this->assertInstanceOf(Sonyflake::class, $model2->id);
 		
 		$this->assertTrue($model2->id->id() > $model1->id->id());
 	}
 
 	/** @param class-string<Model> $class */
 	#[DataProvider('modelClassProvider')]
+	#[DefineEnvironment('usesSonyflakes')]
 	public function test_you_can_set_id_manually(string $class): void
 	{
 		$model = $class::forceCreate(['id' => 123]);
@@ -71,36 +74,36 @@ class SnowflakeCastTest extends TestCase
 	{
 		$with_casts_method = (int) Application::VERSION >= 11;
 
-		return array_filter([
-			'casts property' => [TestModel::class],
-			'casts method' => $with_casts_method ? [TestCastsMethodModel::class] : null,
-			'automatic casting' => [TestAutomaticCastsModel::class],
-		]);
+		return [
+			'casts property' => [TestSonyflakeModel::class],
+			'casts method' => $with_casts_method ? [TestSonyflakeCastsMethodModel::class] : null,
+			'automatic casting' => [TestSonyflakeAutomaticCastsModel::class],
+		];
 	}
 }
 
-class TestModel extends Model
+class TestSonyflakeModel extends Model
 {
 	use HasSnowflakes;
-	
+
 	protected $casts = [
-		'id' => Snowflake::class,
+		'id' => Sonyflake::class,
 	];
 }
 
-class TestCastsMethodModel extends Model
+class TestSonyflakeCastsMethodModel extends Model
 {
 	use HasSnowflakes;
 
 	protected function casts()
 	{
 		return [
-			'id' => Snowflake::class,
+			'id' => Sonyflake::class,
 		];
 	}
 }
 
-class TestAutomaticCastsModel extends Model
+class TestSonyflakeAutomaticCastsModel extends Model
 {
 	use HasSnowflakes;
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,4 +46,9 @@ abstract class TestCase extends Orchestra
 	{
 		return 'America/New_York';
 	}
+
+	protected function usesSonyflakes($app): void
+	{
+		$app['config']->set('bits.format', 'sonyflake');
+	}
 }


### PR DESCRIPTION
This adds in support for automatically merging the snowflake cast for models that use the `HasSnowflakes` trait. This should mean that you can just use `HasSnowflakes` on your model, and not have to explicitly set the cast. It should also respect the global snowflake/sonyflake setting.

It also adds in an additional test for casting `Sonyflake`s, and expands the existing tests to check that everything works with the new `casts()` method from Laravel 11+

Finally, a little housekeeping - the composer scripts was set up to use `pest`, which isn't installed on the project.