### PR TITLE
Fix CacheSequenceResolver for Redis with Compression & Serialization

### DIFF
--- a/src/SequenceResolvers/CacheSequenceResolver.php
+++ b/src/SequenceResolvers/CacheSequenceResolver.php
@@ -3,7 +3,10 @@
 namespace Glhd\Bits\SequenceResolvers;
 
 use Glhd\Bits\Contracts\ResolvesSequences;
+use Illuminate\Cache\RedisStore;
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use Redis;
 
 class CacheSequenceResolver implements ResolvesSequences
 {
@@ -11,13 +14,70 @@ class CacheSequenceResolver implements ResolvesSequences
 		protected Repository $cache
 	) {
 	}
-	
+
 	public function next(int $timestamp): int
 	{
 		$key = "glhd-bits-seq:{$timestamp}";
-		
-		$this->cache->add($key, 0, now()->addSeconds(10));
-		
+
+		$this->withoutSerializationOrCompression(
+			fn() => $this->cache->add($key, 0, now()->addSeconds(10))
+		);
+
 		return $this->cache->increment($key) - 1;
+	}
+
+	protected function withoutSerializationOrCompression(callable $callback)
+	{
+		$store = $this->cache->getStore();
+
+		if (! $store instanceof RedisStore) {
+			return $callback();
+		}
+
+		$connection = $store->connection();
+
+		if (! $connection instanceof PhpRedisConnection) {
+			return $callback();
+		}
+
+		$client = $connection->client();
+
+		$oldSerializer = null;
+
+		if ($this->serialized($client)) {
+			$oldSerializer = $client->getOption($client::OPT_SERIALIZER);
+			$client->setOption($client::OPT_SERIALIZER, $client::SERIALIZER_NONE);
+		}
+
+		$oldCompressor = null;
+
+		if ($this->compressed($client)) {
+			$oldCompressor = $client->getOption($client::OPT_COMPRESSION);
+			$client->setOption($client::OPT_COMPRESSION, $client::COMPRESSION_NONE);
+		}
+
+		try {
+			return $callback();
+		} finally {
+			if ($oldSerializer !== null) {
+				$client->setOption($client::OPT_SERIALIZER, $oldSerializer);
+			}
+
+			if ($oldCompressor !== null) {
+				$client->setOption($client::OPT_COMPRESSION, $oldCompressor);
+			}
+		}
+	}
+
+	public function serialized($client): bool
+	{
+		return defined('Redis::OPT_SERIALIZER') &&
+			$client->getOption(Redis::OPT_SERIALIZER) !== Redis::SERIALIZER_NONE;
+	}
+
+	public function compressed($client): bool
+	{
+		return defined('Redis::OPT_COMPRESSION') &&
+			$client->getOption(Redis::OPT_COMPRESSION) !== Redis::COMPRESSION_NONE;
 	}
 }


### PR DESCRIPTION
Code is now compatible with Compression and Serialization enabled for Redis. 

The implementation is the same as Laravel used for RateLimiting using Redis.

Had to recreate the logic as it is not available on Laravel < 11.x

[src/Illuminate/Cache/RateLimiter.php](https://github.com/laravel/framework/blob/5d477f9a4080c1cdd43edd05ec4df61c738e0f8d/src/Illuminate/Cache/RateLimiter.php#L161)

Without this change, I get this error when trying to create a snowflake ID:
```
InvalidArgumentException 

Sequences must be an integer between 0 and 4095 (got -1).
```