### PR TITLE
Fix for using Redis with compression or serialization in CacheSequenceResolver.php

### DIFF
--- a/src/SequenceResolvers/CacheSequenceResolver.php
+++ b/src/SequenceResolvers/CacheSequenceResolver.php
@@ -9,30 +9,30 @@ use Illuminate\Redis\Connections\PredisConnection;
 
 class CacheSequenceResolver implements ResolvesSequences
 {
-	public function __construct(
-		protected Repository $cache,
-	) {
-	}
+    public function __construct(
+        protected Repository $cache,
+    ) {
+    }
 
-	public function next(int $timestamp): int
-	{
-		$key = "glhd-bits-seq:{$timestamp}";
+    public function next(int $timestamp): int
+    {
+        $key = "glhd-bits-seq:{$timestamp}";
 
-		if ($this->cache->getStore() instanceof RedisStore) {
-			return $this->redisSafeIncrement($key, ttl: 10);
-		}
+        if ($this->cache->getStore() instanceof RedisStore) {
+            return $this->redisSafeIncrement($key, ttl: 10);
+        }
 
-		$this->cache->add($key, 0, now()->addSeconds(10));
+        $this->cache->add($key, 0, now()->addSeconds(10));
 
-		return $this->cache->increment($key) - 1;
-	}
+        return $this->cache->increment($key) - 1;
+    }
 
-	protected function redisSafeIncrement(string $key, int $ttl): int
-	{
-		$store = $this->cache->getStore();
-		$key = $store->getPrefix().$key;
+    protected function redisSafeIncrement(string $key, int $ttl): int
+    {
+        $store = $this->cache->getStore();
+        $key = $store->getPrefix().$key;
 
-		$script = <<<LUA
+        $script = <<<LUA
             local ttl = tonumber(ARGV[1])
             local value = redis.call('INCR', KEYS[1])
             if value == 1 then
@@ -41,12 +41,12 @@ class CacheSequenceResolver implements ResolvesSequences
             return value - 1
         LUA;
 
-		$connection = $store->connection();
+        $connection = $store->connection();
 
-		if ($connection instanceof PredisConnection) {
-			return (int) $connection->client()->eval($script, 1, $key, $ttl);
-		}
+        if ($connection instanceof PredisConnection) {
+            return (int) $connection->client()->eval($script, 1, $key, $ttl);
+        }
 
-		return (int) $connection->client()->eval($script, [$key, $ttl], 1);
-	}
+        return (int) $connection->client()->eval($script, [$key, $ttl], 1);
+    }
 }

--- a/src/SequenceResolvers/CacheSequenceResolver.php
+++ b/src/SequenceResolvers/CacheSequenceResolver.php
@@ -13,40 +13,40 @@ class CacheSequenceResolver implements ResolvesSequences
 		protected Repository $cache,
 	) {
 	}
-
+	
 	public function next(int $timestamp): int
 	{
 		$key = "glhd-bits-seq:{$timestamp}";
-
+		
 		if ($this->cache->getStore() instanceof RedisStore) {
 			return $this->redisSafeIncrement($key, ttl: 10);
 		}
-
+		
 		$this->cache->add($key, 0, now()->addSeconds(10));
-
+		
 		return $this->cache->increment($key) - 1;
 	}
-
+	
 	protected function redisSafeIncrement(string $key, int $ttl): int
 	{
 		$store = $this->cache->getStore();
 		$key = $store->getPrefix().$key;
-
+		
 		$script = <<<LUA
-            local ttl = tonumber(ARGV[1])
-            local value = redis.call('INCR', KEYS[1])
-            if value == 1 then
-                redis.call('EXPIRE', KEYS[1], ttl)
-            end
-            return value - 1
-        LUA;
-
+		local ttl = tonumber(ARGV[1])
+		local value = redis.call('INCR', KEYS[1])
+		if value == 1 then
+		    redis.call('EXPIRE', KEYS[1], ttl)
+		end
+		return value - 1
+		LUA;
+		
 		$connection = $store->connection();
-
+		
 		if ($connection instanceof PredisConnection) {
 			return (int) $connection->client()->eval($script, 1, $key, $ttl);
 		}
-
+		
 		return (int) $connection->client()->eval($script, [$key, $ttl], 1);
 	}
 }


### PR DESCRIPTION
Fixes the issue for all variants PhpRedis, PhpRedis Cluster, Predis & Predis Cluster (tested manually).

- replace withoutSerializationOrCompression() with redisSafeIncrement() that uses a LUA script for RedisStore
- improve performance by using a single Lua script to get the next value from Redis, instead of `add` + `increment`

replaces #16 